### PR TITLE
Update SwiftCLI Version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
           "branch": null,
-          "revision": "37f4a7f863f6fe76ce44fc0023f331eea0089beb",
-          "version": "5.2.0"
+          "revision": "ba2268e67c07b9f9cfbc0801385e6238b36255eb",
+          "version": "5.3.2"
         }
       },
       {

--- a/Sources/GenesisCLI/GenesisCLI.swift
+++ b/Sources/GenesisCLI/GenesisCLI.swift
@@ -16,9 +16,9 @@ public class GenesisCLI {
 //        cli.router = SingleCommandRouter(command: generateCommand)
     }
 
-    public func run(arguments: String? = nil) -> Int32 {
+    public func run(arguments: [String]? = nil) -> Int32 {
         if let arguments = arguments {
-            return cli.debugGo(with: arguments)
+            return cli.go(with: arguments)
         } else {
             return cli.go()
         }

--- a/Sources/GenesisKit/Input.swift
+++ b/Sources/GenesisKit/Input.swift
@@ -11,16 +11,17 @@ extension Input {
 
         let prompt = "\(prompt)\n\(optionsString)"
 
-        let validation: InputReader<String>.Validation = { input in
+        let validation  = Validation<String>.custom("") { input in
             if let index = Int(input), index > 0, index <= options.count {
                 return true
             }
             return options.contains(input)
         }
-        let errorResponse: InputReader<String>.ErrorResponse = { _ in
+        let errorResponse: InputReader<String>.ErrorResponse = { _,_  in
             WriteStream.stderr.print("You must respond with one of the following:\n\(optionsString)")
         }
-        let value = readObject(prompt: prompt, secure: false, validation: validation, errorResponse: errorResponse)
+        
+        let value = Input.readObject(prompt: prompt, secure: false, validation: [validation], errorResponse: errorResponse)
         if options.contains(value) {
             return value
         } else if let index = Int(value) {

--- a/Tests/GenesisCLITests/CLITests.swift
+++ b/Tests/GenesisCLITests/CLITests.swift
@@ -6,8 +6,8 @@ public class CLITests: XCTestCase {
 
     func testCLI() {
         let cli = GenesisCLI()
-        XCTAssertEqual(cli.run(arguments: ["genesis"]), 1)
-        XCTAssertEqual(cli.run(arguments: ["genesis", "invalid"]), 1)
-        XCTAssertEqual(cli.run(arguments: ["generate", "-h"]), 0)
+        XCTAssertEqual(cli.run(arguments: [""]), 1)
+        XCTAssertEqual(cli.run(arguments: ["invalid"]), 1)
+        XCTAssertEqual(cli.run(arguments: ["help"]), 0)
     }
 }

--- a/Tests/GenesisCLITests/CLITests.swift
+++ b/Tests/GenesisCLITests/CLITests.swift
@@ -6,8 +6,8 @@ public class CLITests: XCTestCase {
 
     func testCLI() {
         let cli = GenesisCLI()
-        XCTAssertEqual(cli.run(arguments: "genesis"), 1)
-        XCTAssertEqual(cli.run(arguments: "genesis invalid"), 1)
-        XCTAssertEqual(cli.run(arguments: "genesis -h"), 0)
+        XCTAssertEqual(cli.run(arguments: ["genesis"]), 1)
+        XCTAssertEqual(cli.run(arguments: ["genesis", "invalid"]), 1)
+        XCTAssertEqual(cli.run(arguments: ["generate", "-h"]), 0)
     }
 }


### PR DESCRIPTION
### What's in this pull request?

Update SwiftCLI version to 5.3.2 

### Motivation

When you try to use Genesis as a dependency, SPM always download the latest version of SwiftCLI which cause a compilation error in the package due to breaking changes in the latest version of SwiftCLI