### PR TITLE
Add the Action to Create Only Directories

### DIFF
--- a/Sources/GenesisKit/File.swift
+++ b/Sources/GenesisKit/File.swift
@@ -9,6 +9,7 @@ public struct File: Equatable, Decodable {
     public enum FileType: Equatable {
         case template(String)
         case contents(String)
+        case directory
     }
 
     enum CodingKeys: CodingKey {
@@ -33,10 +34,12 @@ public struct File: Equatable, Decodable {
         if let contents = try container.decodeIfPresent(String.self, forKey: .contents) {
             type = .contents(contents)
             path = try container.decode(String.self, forKey: .path)
-        } else {
-            let template = try container.decode(String.self, forKey: .template)
+        } else if let template = try container.decodeIfPresent(String.self, forKey: .template) {
             type = .template(template)
-            path = try container.decodeIfPresent(String.self, forKey: .path) ?? template
+            path = try container.decode(String.self, forKey: .path)
+        } else {
+            type = .directory
+            path = try container.decode(String.self, forKey: .path)
         }
     }
 }

--- a/Sources/GenesisKit/TemplateGenerator.swift
+++ b/Sources/GenesisKit/TemplateGenerator.swift
@@ -117,10 +117,11 @@ public class TemplateGenerator {
                     return
                 }
             }
-            let fileContents: String
+            let fileContents: String?
             switch file.type {
             case let .template(path): fileContents = try environment.renderTemplate(name: path, context: context)
             case let .contents(string): fileContents = try replaceString(string, context: context)
+            case .directory: fileContents = nil
             }
             let replacedPath = try replaceString(file.path, context: context)
             let generatedFile = GeneratedFile(path: Path(replacedPath), contents: fileContents)
@@ -172,15 +173,19 @@ public struct GenerationResult {
 
         for file in files {
             let filePath = path + file.path
-            try filePath.parent().mkpath()
-            try filePath.write(file.contents)
+            if let contents = file.contents {
+                try filePath.parent().mkpath()
+                try filePath.write(contents)
+            } else {
+                try filePath.mkpath()
+            }
         }
     }
 }
 
 public struct GeneratedFile: Equatable, CustomStringConvertible {
     public let path: Path
-    public let contents: String
+    public let contents: String?
 
     public var description: String {
         return path.string


### PR DESCRIPTION
## Motivation and Context
If you can create only empty directories, it will be easier for users to know where to create files.
If the file is not needed, the directory will not be shared unless the file is created.
Therefore, I greatly appreciate having this feature, which creates only empty directories.

## Description
This PR  enables you to create only directories by describing the path.
No template is required.
```yaml
files:
- path: "MyGroup/MyChild/"
```