### PR TITLE
Remove warning

### DIFF
--- a/Sources/GenesisCLI/GenerateCommand.swift
+++ b/Sources/GenesisCLI/GenerateCommand.swift
@@ -10,7 +10,7 @@ class GenerateCommand: Command {
     let name = "generate"
     let shortDescription = "Generates files based on a template"
 
-    let templatePath = Parameter()
+    let templatePath = Param<String>()
 
     let optionPath = Key<String>("-p", "--option-path", description: "Path to a yaml or json file containing options")
 

--- a/Sources/GenesisKit/TemplateGenerator.swift
+++ b/Sources/GenesisKit/TemplateGenerator.swift
@@ -32,7 +32,7 @@ public class TemplateGenerator {
     }
 
     fileprivate func getOptionValue(_ option: Option, context: inout Context) throws {
-        if let value = context[option.name] {
+        if context[option.name] != nil {
             // found existing option
             return
         }


### PR DESCRIPTION
Removed the following warnings.

- `‘Parameter’ is deprecated: use Param<String>` in `Sources/GenesisCLI/GenerateCommand.swift`
- `Value ‘value’ was defined but never used; consider replacing with boolean test` in `Sources/GenesisKit/TemplateGenerator.swift`
