### PR TITLE
Update dependencies to latest

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/shibapm/Komondor.git",
         "state": {
           "branch": null,
-          "revision": "7c3c6040c01c99b83afc7eaa8f2a8a69337f659a",
-          "version": "1.1.1"
+          "revision": "90b087b1e39069684b1ff4bf915c2aae594f2d60",
+          "version": "1.1.3"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
         "state": {
           "branch": null,
-          "revision": "84d4d70de31a797ca54abee47816cdafba36d290",
-          "version": "1.0.2"
+          "revision": "58523193c26fb821ed1720dcd8a21009055c7cdb",
+          "version": "1.1.3"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/onevcat/Rainbow",
         "state": {
           "branch": null,
-          "revision": "797a68d0a642609424b08f11eb56974a54d5f6e2",
-          "version": "3.1.4"
+          "revision": "e0dada9cd44e3fa7ec3b867e49a8ddbf543e3df3",
+          "version": "4.0.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "973e190edf5d09274e4a6bc2e636c86899ed84c3",
-          "version": "0.14.1"
+          "revision": "ccd9402682f4c07dac9561befd207c8156e80e20",
+          "version": "0.14.2"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams",
         "state": {
           "branch": null,
-          "revision": "26ab35f50ea891e8edefcc9d975db2f6b67e1d68",
-          "version": "1.0.1"
+          "revision": "00c403debcd0a007b854bb35e598466207a2d58c",
+          "version": "5.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,10 +10,10 @@ let package = Package(
         .library(name: "GenesisKit", targets: ["GenesisKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/SwiftGen/StencilSwiftKit", from: "2.7.0"),
-        .package(url: "https://github.com/jpsim/Yams", from: "1.0.0"),
+        .package(url: "https://github.com/SwiftGen/StencilSwiftKit", from: "2.8.0"),
+        .package(url: "https://github.com/jpsim/Yams", from: "5.0.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "1.0.1"),
-        .package(url: "https://github.com/onevcat/Rainbow", from: "3.1.0"),
+        .package(url: "https://github.com/onevcat/Rainbow", from: "4.0.1"),
         .package(url: "https://github.com/jakeheis/SwiftCLI", from: "6.0.3"),
     ],
     targets: [


### PR DESCRIPTION
Update dependencies to latest.
Resolve compatibility with other libraries.

- [SwiftGen/StencilSwiftKit v2.8.0](https://github.com/SwiftGen/StencilSwiftKit/releases/tag/2.8.0)
- [jpsim/Yams v5.0.0](https://github.com/jpsim/Yams/releases/tag/5.0.0)
- [onevcat/Rainbow v4.0.1](https://github.com/onevcat/Rainbow/releases/tag/4.0.1)