### PR TITLE
Fix inline options array parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.xcodeproj
 .swiftpm/*
 .vscode/
+.context/

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Options:
   -d, --destination <value>    Path to the directory where output will be generated. Defaults to the current directory
   -h, --help                   Show help information for this command
   -n, --non-interactive        Do not prompt for required options
-  -o, --options <value>        Provide option overrides, in the format --options "option1: value 2, option2: value 2.
+  -o, --options <value>        Provide option overrides, in the format --options "option1: value 1, option2: [value 2, value 3]". Escape literal commas as \,.
   -p, --option-path <value>    Path to a yaml or json file containing options
 ```
 
@@ -126,7 +126,19 @@ targets:
 Pass specific options with `--options` like this
 
 ```
--- options "option1: value 2, option2: value 2"
+--options "option1: value 1, option2: value 2"
+```
+
+Inline array values can be passed with brackets:
+
+```
+--options "actions: [tap, refresh, dismiss]"
+```
+
+Only the first `:` separates a key from its value, so values like URLs can be passed directly. Escape commas that are part of a scalar value with `\`.
+
+```
+--options "url: https://example.com/path:segment, title: Hello\, world"
 ```
 
 #### 4. Interactive input

--- a/Sources/GenesisCLI/CommandLineOptionsParser.swift
+++ b/Sources/GenesisCLI/CommandLineOptionsParser.swift
@@ -1,0 +1,183 @@
+import Foundation
+import GenesisKit
+
+enum CommandLineOptionsParserError: Error, CustomStringConvertible, LocalizedError, Equatable {
+    case malformedOption(String)
+    case emptyKey(String)
+    case emptyArrayItem(String)
+    case duplicateKey(String)
+    case danglingEscape(String)
+    case unmatchedClosingBracket(String)
+    case unterminatedArray(String)
+
+    var description: String {
+        switch self {
+        case .malformedOption(let option):
+            return "Malformed option '\(option)'. Expected 'key: value'."
+        case .emptyKey(let option):
+            return "Malformed option '\(option)'. Option keys cannot be empty."
+        case .emptyArrayItem(let option):
+            return "Malformed option '\(option)'. Array items cannot be empty."
+        case .duplicateKey(let key):
+            return "Duplicate option '\(key)'. Use bracket array syntax for array values."
+        case .danglingEscape(let option):
+            return "Malformed option '\(option)'. Escape character must be followed by a value."
+        case .unmatchedClosingBracket(let option):
+            return "Malformed option '\(option)'. Found ']' without a matching '['."
+        case .unterminatedArray(let option):
+            return "Malformed option '\(option)'. Array value is missing a closing ']'."
+        }
+    }
+
+    var errorDescription: String? {
+        return description
+    }
+}
+
+struct CommandLineOptionsParser {
+
+    static func parse(_ string: String) throws -> Context {
+        var context: Context = [:]
+        let optionList = try splitTopLevel(string, separator: ",")
+
+        for option in optionList {
+            let trimmedOption = option.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedOption.isEmpty {
+                throw CommandLineOptionsParserError.malformedOption(option)
+            }
+
+            let (key, value) = try parseOption(trimmedOption)
+            guard context[key] == nil else {
+                throw CommandLineOptionsParserError.duplicateKey(key)
+            }
+            context[key] = value
+        }
+
+        return context
+    }
+
+    private static func parseOption(_ option: String) throws -> (String, Any) {
+        guard let separatorIndex = try firstUnescapedColon(in: option) else {
+            throw CommandLineOptionsParserError.malformedOption(option)
+        }
+
+        let key = String(option[..<separatorIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
+        if key.isEmpty {
+            throw CommandLineOptionsParserError.emptyKey(option)
+        }
+
+        let valueStart = option.index(after: separatorIndex)
+        let value = String(option[valueStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return (key, try parseValue(value, option: option))
+    }
+
+    private static func parseValue(_ value: String, option: String) throws -> Any {
+        if value.hasPrefix("[") {
+            guard value.hasSuffix("]") else {
+                throw CommandLineOptionsParserError.unterminatedArray(option)
+            }
+
+            let start = value.index(after: value.startIndex)
+            let end = value.index(before: value.endIndex)
+            let arrayString = String(value[start..<end])
+            if arrayString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return [String]()
+            }
+
+            return try splitTopLevel(arrayString, separator: ",").map { item -> String in
+                let trimmedItem = item.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmedItem.isEmpty {
+                    throw CommandLineOptionsParserError.emptyArrayItem(option)
+                }
+                return try unescape(trimmedItem, option: option)
+            }
+        }
+
+        return try unescape(value, option: option)
+    }
+
+    private static func firstUnescapedColon(in string: String) throws -> String.Index? {
+        var isEscaping = false
+
+        for index in string.indices {
+            let character = string[index]
+            if isEscaping {
+                isEscaping = false
+            } else if character == "\\" {
+                isEscaping = true
+            } else if character == ":" {
+                return index
+            }
+        }
+
+        if isEscaping {
+            throw CommandLineOptionsParserError.danglingEscape(string)
+        }
+
+        return nil
+    }
+
+    private static func splitTopLevel(_ string: String, separator: Character) throws -> [String] {
+        var parts: [String] = []
+        var current = ""
+        var bracketDepth = 0
+        var isEscaping = false
+
+        for character in string {
+            if isEscaping {
+                current.append("\\")
+                current.append(character)
+                isEscaping = false
+            } else if character == "\\" {
+                isEscaping = true
+            } else if character == "[" {
+                bracketDepth += 1
+                current.append(character)
+            } else if character == "]" {
+                guard bracketDepth > 0 else {
+                    throw CommandLineOptionsParserError.unmatchedClosingBracket(string)
+                }
+                bracketDepth -= 1
+                current.append(character)
+            } else if character == separator && bracketDepth == 0 {
+                parts.append(current)
+                current = ""
+            } else {
+                current.append(character)
+            }
+        }
+
+        if isEscaping {
+            throw CommandLineOptionsParserError.danglingEscape(string)
+        }
+
+        if bracketDepth > 0 {
+            throw CommandLineOptionsParserError.unterminatedArray(string)
+        }
+
+        parts.append(current)
+        return parts
+    }
+
+    private static func unescape(_ string: String, option: String) throws -> String {
+        var result = ""
+        var isEscaping = false
+
+        for character in string {
+            if isEscaping {
+                result.append(character)
+                isEscaping = false
+            } else if character == "\\" {
+                isEscaping = true
+            } else {
+                result.append(character)
+            }
+        }
+
+        if isEscaping {
+            throw CommandLineOptionsParserError.danglingEscape(option)
+        }
+
+        return result
+    }
+}

--- a/Sources/GenesisCLI/GenerateCommand.swift
+++ b/Sources/GenesisCLI/GenerateCommand.swift
@@ -16,7 +16,7 @@ class GenerateCommand: Command {
 
     let destinationPath = Key<String>("-d", "--destination", description: "Path to the directory where output will be generated. Defaults to the current directory")
 
-    let optionsArgument = Key<String>("-o", "--options", description: "Provide option overrides, in the format --options \"option1: value 2, option2: value 2.")
+    let optionsArgument = Key<String>("-o", "--options", description: "Provide option overrides, in the format --options \"option1: value 1, option2: [value 2, value 3]\". Escape literal commas as \\,.")
 
     let nonInteractive = Flag("-n", "--non-interactive", description: "Do not prompt for required options")
 
@@ -55,22 +55,7 @@ class GenerateCommand: Command {
 
         // extract options from options argument
         if let commandLineOptions = optionsArgument.value {
-            let optionList: [String] = commandLineOptions
-                .split(separator: ",")
-                .map(String.init)
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-
-            let optionPairs: [(String, String)] = optionList
-                .map { option in
-                    option
-                        .split(separator: ":")
-                        .map(String.init)
-                        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                }
-                .filter { $0.count == 2 }
-                .map { ($0[0], $0[1]) }
-
-            for (key, value) in optionPairs {
+            for (key, value) in try CommandLineOptionsParser.parse(commandLineOptions) {
                 context[key] = value
             }
         }

--- a/Tests/GenesisCLITests/CLITests.swift
+++ b/Tests/GenesisCLITests/CLITests.swift
@@ -1,4 +1,4 @@
-import GenesisCLI
+@testable import GenesisCLI
 import SwiftCLI
 import XCTest
 
@@ -9,5 +9,50 @@ public class CLITests: XCTestCase {
         XCTAssertEqual(cli.run(arguments: [""]), 1)
         XCTAssertEqual(cli.run(arguments: ["invalid"]), 1)
         XCTAssertEqual(cli.run(arguments: ["help"]), 0)
+    }
+
+    func testOptionsParserParsesSingleScalarOption() throws {
+        let context = try CommandLineOptionsParser.parse("name: Foo")
+
+        XCTAssertEqual(context["name"] as? String, "Foo")
+    }
+
+    func testOptionsParserParsesMultipleScalarOptions() throws {
+        let context = try CommandLineOptionsParser.parse("name: Foo, enabled: true")
+
+        XCTAssertEqual(context["name"] as? String, "Foo")
+        XCTAssertEqual(context["enabled"] as? String, "true")
+    }
+
+    func testOptionsParserParsesBracketArrayOption() throws {
+        let context = try CommandLineOptionsParser.parse("actions: [tap, refresh, dismiss]")
+
+        XCTAssertEqual(context["actions"] as? [String], ["tap", "refresh", "dismiss"])
+    }
+
+    func testOptionsParserPreservesColonInValue() throws {
+        let context = try CommandLineOptionsParser.parse("url: https://example.com/path:segment, name: Foo")
+
+        XCTAssertEqual(context["url"] as? String, "https://example.com/path:segment")
+        XCTAssertEqual(context["name"] as? String, "Foo")
+    }
+
+    func testOptionsParserPreservesEscapedCommaInValue() throws {
+        let context = try CommandLineOptionsParser.parse("title: Hello\\, world, name: Foo")
+
+        XCTAssertEqual(context["title"] as? String, "Hello, world")
+        XCTAssertEqual(context["name"] as? String, "Foo")
+    }
+
+    func testOptionsParserThrowsForMalformedEntry() {
+        XCTAssertThrowsError(try CommandLineOptionsParser.parse("name: Foo, malformed")) { error in
+            XCTAssertEqual(error as? CommandLineOptionsParserError, .malformedOption("malformed"))
+        }
+    }
+
+    func testOptionsParserThrowsForDuplicateKey() {
+        XCTAssertThrowsError(try CommandLineOptionsParser.parse("actions: tap, actions: refresh")) { error in
+            XCTAssertEqual(error as? CommandLineOptionsParserError, .duplicateKey("actions"))
+        }
     }
 }


### PR DESCRIPTION
This PR replaces the naive inline --options splitter with a parser that supports bracket array values, preserves colons in scalar values, supports escaped literal commas, and reports malformed input instead of dropping it. Duplicate option keys now fail clearly so bracket syntax is the single inline array form. It updates CLI help and README examples, adds parser unit tests, and ignores Conductor's .context directory.