### PR TITLE
Update CI to Xcode 26

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,11 @@ on:
   pull_request: {}
 jobs:
   run:
-    runs-on: macos-11
+    runs-on: macos-15
     name: Xcode ${{ matrix.xcode }}
     strategy:
       matrix:
-        xcode: ["13.0"]
+        xcode: ["26.1.1"]
     steps:
     - uses: actions/checkout@master
     - name: Set Xcode
@@ -25,4 +25,4 @@ jobs:
     - name: Build
       run: swift build
     - name: Test
-      run: swift test 2>&1 | xcpretty
+      run: swift test 2>&1 | xcbeautify


### PR DESCRIPTION
## Summary
Updates the CI workflow to build and test on Xcode 26.

## Changes
- Bump runner from `macos-11` to `macos-15` (required for Xcode 26)
- Update Xcode matrix from `13.0` to `26.1.1` (earliest 26.x on the `macos-15` image; only `26.1.1`, `26.2`, `26.3` are available)
- Replace `xcpretty` with `xcbeautify` — `xcpretty` is no longer preinstalled on the runner image, while `xcbeautify` is (v3.2.1)

## Notes
- `2>&1` is retained: `swift test` sends build progress and compile-error diagnostics to stderr, so it must be redirected for xcbeautify to format failures. This matches xcbeautify's documented SPM usage (`swift test [flags] 2>&1 | xcbeautify`).
- Exit-code safety on the pipe is already provided by GitHub Actions' default `bash -eo pipefail` shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)